### PR TITLE
Fix #61: Make code span background color lighter

### DIFF
--- a/src/styles/remark-code.css
+++ b/src/styles/remark-code.css
@@ -52,10 +52,10 @@
   }
   padding: 0.15rem 0.3rem;
   border-radius: 0.25rem;
-  background-color: #e5e5e5;
+  background-color: #f0f0f0; /* Lighter background for light mode */
   color: #525252;
   @media (prefers-color-scheme: dark) {
-    background-color: #404040 !important;
+    background-color: #2a2a2a !important; /* Lighter background for dark mode */
     color: #e5e5e5 !important;
   }
 }

--- a/src/styles/remark-code.css
+++ b/src/styles/remark-code.css
@@ -52,10 +52,10 @@
   }
   padding: 0.15rem 0.3rem;
   border-radius: 0.25rem;
-  background-color: #f0f0f0;
+  background-color: #f8f8f8;
   color: #525252;
   @media (prefers-color-scheme: dark) {
-    background-color: #2a2a2a !important;
+    background-color: #212121 !important;
     color: #e5e5e5 !important;
   }
 }

--- a/src/styles/remark-code.css
+++ b/src/styles/remark-code.css
@@ -52,10 +52,10 @@
   }
   padding: 0.15rem 0.3rem;
   border-radius: 0.25rem;
-  background-color: #f0f0f0; /* Lighter background for light mode */
+  background-color: #f0f0f0;
   color: #525252;
   @media (prefers-color-scheme: dark) {
-    background-color: #2a2a2a !important; /* Lighter background for dark mode */
+    background-color: #2a2a2a !important;
     color: #e5e5e5 !important;
   }
 }


### PR DESCRIPTION
This PR addresses issue #61 by making the background color of code spans lighter.

- Changed the background color in light mode from `#e5e5e5` to `#f0f0f0`
- Changed the background color in dark mode from `#404040` to `#2a2a2a`

These changes make the code spans more readable and less visually distracting.