### PR TITLE
dependabotの設定改善

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,54 +8,52 @@ updates:
   - package-ecosystem: bun # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
-      interval: 'weekly'
-      day: 'friday'
-      time: '21:00'
+      interval: 'daily'
+      time: '10:00'
       timezone: 'Asia/Tokyo'
     groups:
-      astro-packages:
+      astro:
         patterns:
           - '@astrojs*'
           - 'astro*'
         update-types:
           - 'minor'
           - 'patch'
-      tailwind-packages:
+      tailwind:
         patterns:
           - '@tailwindcss*'
           - 'tailwindcss'
         update-types:
           - 'minor'
           - 'patch'
-      postcss-packages:
+      postcss:
         patterns:
           - 'postcss*'
           - 'autoprefixer'
         update-types:
           - 'minor'
           - 'patch'
-      markdown-packages:
+      markdown:
         patterns:
           - 'rehype*'
           - 'remark*'
         update-types:
           - 'minor'
           - 'patch'
-      icon-packages:
+      icon:
         patterns:
           - '@iconify-json*'
         update-types:
           - 'minor'
           - 'patch'
-      dev-typescript:
+      typescript:
         patterns:
           - 'typescript'
           - '@types/*'
         update-types:
           - 'minor'
           - 'patch'
-      dev-eslint:
-        dependency-type: 'development'
+      eslint:
         patterns:
           - '@eslint*'
           - 'eslint*'
@@ -64,8 +62,7 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-      dev-prettier:
-        dependency-type: 'development'
+      prettier:
         patterns:
           - 'prettier*'
         update-types:


### PR DESCRIPTION
## 変更内容

このPRではdependabotの設定を改善し、より効率的な依存関係管理を実現します。

### 主な変更点

1. **更新スケジュールの変更**：
   - 週1回（金曜21:00）から毎日（10:00）に変更
   - これにより、セキュリティアップデートや重要な修正をより迅速に適用可能になります

2. **依存関係グループ名の簡略化**：
   - 全てのグループ名をより簡潔に変更（例：`astro-packages` → `astro`）
   - 設定ファイルの可読性と保守性が向上します

3. **不要な設定の削除**：
   - `eslint`と`prettier`グループから`dependency-type: 'development'`設定を削除
   - グループのパターンマッチングで既に適切に分類されているため冗長でした

### 期待される効果

- より頻繁な依存関係の更新確認によるセキュリティの向上
- シンプルになった設定ファイルによる保守性の向上
- PRの管理がしやすくなることによる開発効率の向上

### 技術的詳細

- 変更対象ファイル: `.github/dependabot.yml`
- 更新頻度: `weekly` → `daily`
- タイムゾーン設定: 変更なし（`Asia/Tokyo`を維持） 