### PR TITLE
Update Dependabot to weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
   - package-ecosystem: npm # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'monday'
       time: '10:00'
       timezone: 'Asia/Tokyo'
     groups:


### PR DESCRIPTION
Changed Dependabot schedule from daily to weekly (every Monday at 10:00 JST) to reduce update frequency.