### PR TITLE
ci: simplify `build:ci` to run `astro build` and document hook behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v6
@@ -41,4 +42,4 @@ jobs:
         run: pnpm run lint
 
       - name: Build
-        run: pnpm run build
+        run: pnpm run build:ci

--- a/docs/ci-scripts.md
+++ b/docs/ci-scripts.md
@@ -1,0 +1,21 @@
+# CI向けスクリプト
+
+## `build:ci`
+
+```bash
+pnpm run build:ci
+```
+
+CIでビルドだけを実行するためのスクリプトです。
+
+- 実行内容: `astro build`
+- `build:ci` 自体のコマンドとして `astro build` を直接実行します。
+- `prebuild` は `build` スクリプトに紐づくフック名のため、`pnpm run build:ci` では実行されません。
+- このリポジトリのCIでは `lint` を独立ステップで実行しているため、`prebuild` の重複実行を避ける目的で使います。
+
+## 使い分け
+
+- ローカル開発: `pnpm run build`
+  - `prebuild` が有効で、`pnpm lint` を先に実行します。
+- CI: `pnpm run build:ci`
+  - `prebuild` をスキップし、ビルドのみ実行します。

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev:host": "astro dev --host",
     "prebuild": "pnpm lint",
     "build": "astro build",
+    "build:ci": "astro build",
     "preview": "astro preview",
     "preview:workers": "wrangler dev",
     "deploy": "wrangler deploy",


### PR DESCRIPTION
### Motivation

- Make the CI build command simple and explicit by running the core build tool directly. 
- Avoid running `prebuild` (which runs `pnpm lint`) in the CI build step to prevent redundant linting already executed as a separate CI step.

### Description

- Updated `package.json` to set `build:ci` to `astro build` so the CI script runs the build tool directly. 
- Added `docs/ci-scripts.md` documenting that `build:ci` runs `astro build` and that `prebuild` is scoped to the `build` lifecycle so it does not run for `build:ci`. 
- CI workflow (`.github/workflows/ci.yml`) continues to call `pnpm run build:ci` and includes a `timeout-minutes: 15` for the job.

### Testing

- Ran `pnpm run lint` and it completed successfully with no errors. 
- Ran `pnpm run build:ci` and the build completed successfully (noting non-fatal Open Graph fetch errors from `remark-link-card-plus` were logged but the build finished).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6990cf18fac4832db00d7c3310fa044e)