### PR TITLE
[codex] Support markdown Accept header for posts

### DIFF
--- a/docs/raw-markdown-endpoints.md
+++ b/docs/raw-markdown-endpoints.md
@@ -1,6 +1,6 @@
 # Raw Markdown エンドポイント
 
-ブログ記事の HTML ページに加えて、frontmatter を含む raw Markdown を取得できる `.md` エンドポイントを提供しています。Astro の表示制御用 `layout` frontmatter は出力しません。
+ブログ記事の HTML ページに加えて、frontmatter を含む raw Markdown を取得できます。Astro の表示制御用 `layout` frontmatter は出力しません。
 
 ## URL
 
@@ -13,10 +13,11 @@
 
 - `/posts/foo`: 通常の HTML 記事ページ
 - `/posts/foo.md`: frontmatter 込みの raw Markdown（`layout` は除外）
+- `/posts/foo` または `/posts/foo/` に `Accept: text/markdown` を付けたリクエスト: frontmatter 込みの raw Markdown（`layout` は除外）
 
 ## 実装
 
-Endpoint は `src/pages/posts/[slug].md.ts` で実装しています。
+Raw Markdown の生成は `src/pages/posts/[slug].md.ts` に集約しています。
 
 - `import.meta.glob('./*.md', { query: '?raw', import: 'default', eager: true })` で `src/pages/posts/` 直下の記事 Markdown を文字列として読み込む
 - `getStaticPaths()` で記事ごとの `slug` を列挙し、静的ビルド時に `/posts/[slug].md` を生成する
@@ -24,6 +25,8 @@ Endpoint は `src/pages/posts/[slug].md.ts` で実装しています。
 - `GET` は raw Markdown を `Content-Type: text/markdown; charset=utf-8` で返す
 
 `template/_blog-post.md` や画像ディレクトリ配下のファイルは、`./*.md` の対象外です。
+
+`/posts/[slug]/` への `Accept: text/markdown` リクエストは Cloudflare Workers の `worker/index.js` で処理します。Worker は `wrangler.toml` の `assets.run_worker_first = ["/posts/*"]` により記事 URL だけ先に実行され、該当リクエストを既存の `/posts/[slug].md` アセットに差し替えて返します。HTML と Markdown が同じ URL で変化するため、記事 URL のレスポンスには `Vary: Accept` を付与します。
 
 ## 動作確認
 

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,76 @@
+const MARKDOWN_CONTENT_TYPE = 'text/markdown; charset=utf-8';
+
+const isMarkdownAccepted = (request) =>
+  request.headers
+    .get('Accept')
+    ?.split(',')
+    .some(
+      (acceptValue) =>
+        acceptValue.trim().toLowerCase().split(';', 1)[0] === 'text/markdown',
+    ) ?? false;
+
+const getPostSlug = (url) =>
+  url.pathname.match(/^\/posts\/([^/.][^/]*)\/?$/)?.[1] ?? null;
+
+const createMarkdownAssetRequest = (request, slug) => {
+  const markdownUrl = new URL(request.url);
+  markdownUrl.pathname = `/posts/${slug}.md`;
+  markdownUrl.search = '';
+
+  return new Request(markdownUrl, request);
+};
+
+const withVaryAccept = (response) => {
+  const headers = new Headers(response.headers);
+  const vary = headers.get('Vary');
+
+  if (!vary) {
+    headers.set('Vary', 'Accept');
+  } else if (
+    !vary
+      .split(',')
+      .some((varyValue) => varyValue.trim().toLowerCase() === 'accept')
+  ) {
+    headers.set('Vary', `${vary}, Accept`);
+  }
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+};
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const slug = getPostSlug(url);
+    const canReturnMarkdown =
+      slug &&
+      (request.method === 'GET' || request.method === 'HEAD') &&
+      isMarkdownAccepted(request);
+
+    if (canReturnMarkdown) {
+      const markdownResponse = await env.ASSETS.fetch(
+        createMarkdownAssetRequest(request, slug),
+      );
+
+      if (markdownResponse.ok) {
+        const headers = new Headers(markdownResponse.headers);
+        headers.set('Content-Type', MARKDOWN_CONTENT_TYPE);
+
+        return withVaryAccept(
+          new Response(markdownResponse.body, {
+            headers,
+            status: markdownResponse.status,
+            statusText: markdownResponse.statusText,
+          }),
+        );
+      }
+    }
+
+    const assetResponse = await env.ASSETS.fetch(request);
+
+    return slug ? withVaryAccept(assetResponse) : assetResponse;
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,8 @@
 name = "blog"
 compatibility_date = "2025-07-26"
+main = "./worker/index.js"
 
 [assets]
 directory = "./dist"
+binding = "ASSETS"
+run_worker_first = ["/posts/*"]


### PR DESCRIPTION
## Summary

- Add a small Cloudflare Worker in front of `/posts/*` so article pages can return Markdown when the request includes `Accept: text/markdown`.
- Reuse the existing `/posts/[slug].md` generated asset for the Markdown body, keeping raw Markdown generation in `src/pages/posts/[slug].md.ts`.
- Add `Vary: Accept` for article URL responses and document the behavior in `docs/raw-markdown-endpoints.md`.

## Validation

- `pnpm run lint && pnpm run build`
- `pnpm exec wrangler deploy --dry-run`
- Local `wrangler dev` smoke test:
  - `/posts/remark-link-card-with-astro/` returns `Content-Type: text/html; charset=utf-8`
  - the same URL with `Accept: text/markdown` returns `Content-Type: text/markdown; charset=utf-8` and YAML frontmatter
