### PR TITLE
test: RSS フィードの E2E テストを追加

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -40,7 +40,8 @@ tests/e2e/
 ├── pages/                    # ページオブジェクト
 │   ├── home-page.ts          # ホーム (/)
 │   ├── about-page.ts         # About (/about)
-│   └── article-page.ts       # 記事ページ
+│   ├── article-page.ts       # 記事ページ
+│   └── rss-feed-page.ts      # RSS フィード (/rss.xml)
 ├── fixtures/
 │   └── test.ts               # 共通 fixture
 ├── utils/
@@ -52,7 +53,8 @@ tests/e2e/
     ├── smoke.spec.ts         # 基本表示の確認
     ├── navigation.spec.ts    # ヘッダー/フッターの遷移確認
     ├── theme.spec.ts         # テーマ切り替えの確認
-    └── visual.spec.ts        # ビジュアルリグレッション
+    ├── visual.spec.ts        # ビジュアルリグレッション
+    └── rss.spec.ts           # RSS フィードの確認
 ```
 
 ビジュアルスナップショットは `tests/e2e/specs/visual.spec.ts-snapshots/` に保存します。`snapshotPathTemplate` で OS サフィックスを外し、プロジェクト名だけを付けます。例: `article-metadata-chromium.png`
@@ -73,7 +75,7 @@ tests/e2e/
 
 `@playwright/test` の `base` を拡張し、spec から以下を利用できるようにしています。
 
-- `homePage` / `aboutPage` / `articlePage`: 対応するページオブジェクト
+- `homePage` / `aboutPage` / `articlePage` / `rssFeedPage`: 対応するページオブジェクト
 - `isDesktop`: viewport 幅（768px 以上）からデスクトッププロジェクトかどうかを判定する boolean。モバイルでヘッダーメニューを開くかどうかの分岐に使う
 
 `isDesktop` が false（モバイル）のときは、ヘッダーのナビ/テーマトグルがハンバーガーメニュー内に隠れるため、`header.openMobileMenu()` でメニューを開いてから操作します。
@@ -87,6 +89,7 @@ export const routes = {
   home: '/',
   about: '/about',
   sampleArticle: '/posts/audio-interface-under-the-desk',
+  rss: '/rss.xml',
 } as const;
 
 export const sampleArticleTitle = 'オーディオインターフェースを机の裏に設置した';
@@ -116,6 +119,7 @@ export const sampleArticleTitle = 'オーディオインターフェースを机
 - `home-page.ts`: `goto()`、`header`、`footer`、`postList`
 - `about-page.ts`: `goto()`、`header`、`footer`、`heading`
 - `article-page.ts`: `goto(route, title)`、`header`、`footer`、`metadata`、`heading`
+- `rss-feed-page.ts`: `goto()`、`response`、`content()`。RSS はブラウザ描画ではなく XML 応答のため `APIRequestContext` で取得し、`DOMParser` でパースする。`response` はステータス・ヘッダー検証用、`content()` はパース済みのチャネル/アイテムを返す
 
 ## spec の内容
 
@@ -160,6 +164,17 @@ export const sampleArticleTitle = 'オーディオインターフェースを机
 ```sh
 sudo apt-get install fonts-noto-cjk
 ```
+
+### RSS フィードテスト (`rss.spec.ts`)
+
+`/rss.xml` はブログ購読用の配信面。XML 応答を `APIRequestContext` で取得し、`DOMParser` でパースして検証する。ブラウザエンジンやビューポートに依存しないため、Chromium 1 プロジェクトのみで実行する（それ以外は `test.skip` でスキップ）。
+
+検証内容:
+
+- `/rss.xml` が 200 で応答し、`content-type` が XML 系（`application/xml` 等）であること。
+- `<channel>` にサイト名（`config.siteName`）・説明・`<language>ja-jp</language>` が含まれること。
+- 代表記事（`sampleArticleTitle`）のタイトルとリンクが `<item>` に含まれること。リンクはホスト・末尾スラッシュの差異に依存しないようパスで部分一致させる。
+- frontmatter 不足記事の扱い: `src/pages/rss.xml.ts` の `hasRequiredFrontmatter` により、`title` または `pubDate` frontmatter を持たない記事はフィードから除外される。本リポジトリに draft 扱いは存在せず、この frontmatter 条件のみで絞り込む。記事テンプレート (`src/pages/posts/template/_blog-post.md`) は `title` が未設定のため除外され、フィードに出現しないことを検証する（全 `<item>` が空でない `title`・`link` を持つこと、および `/template/` を含むリンクがないこと）。
 
 ### スナップショットの更新
 

--- a/tests/e2e/fixtures/test.ts
+++ b/tests/e2e/fixtures/test.ts
@@ -2,18 +2,20 @@ import { test as base, expect } from '@playwright/test';
 import { HomePage } from '../pages/home-page';
 import { AboutPage } from '../pages/about-page';
 import { ArticlePage } from '../pages/article-page';
+import { RssFeedPage } from '../pages/rss-feed-page';
 
 /**
  * ブログ E2E スイートで共有する Playwright fixture。
  *
- * spec 側で `homePage` / `aboutPage` / `articlePage` を毎回生成しなくて済むようにする。
- * `isDesktop` は、viewport の数値を各 spec に直接書かずにデスクトップ限定のテストを
- * 表現するために使う。
+ * spec 側で `homePage` / `aboutPage` / `articlePage` / `rssFeedPage` を毎回生成
+ * しなくて済むようにする。`isDesktop` は、viewport の数値を各 spec に直接書かずに
+ * デスクトップ限定のテストを表現するために使う。
  */
 export const test = base.extend<{
   homePage: HomePage;
   aboutPage: AboutPage;
   articlePage: ArticlePage;
+  rssFeedPage: RssFeedPage;
   isDesktop: boolean;
 }>({
   homePage: async ({ page }, use) => {
@@ -24,6 +26,9 @@ export const test = base.extend<{
   },
   articlePage: async ({ page }, use) => {
     await use(new ArticlePage(page));
+  },
+  rssFeedPage: async ({ page, request }, use) => {
+    await use(new RssFeedPage(page, request));
   },
   isDesktop: async ({ page }, use) => {
     await use((page.viewportSize()?.width ?? 1280) >= 768);

--- a/tests/e2e/pages/rss-feed-page.ts
+++ b/tests/e2e/pages/rss-feed-page.ts
@@ -1,0 +1,79 @@
+import {
+  type APIRequestContext,
+  type APIResponse,
+  type Page,
+} from '@playwright/test';
+import { routes } from '../utils/routes';
+
+/** RSS `<item>` のうち本スイートで検証に使うフィールド。 */
+export interface RssFeedItem {
+  title: string;
+  link: string;
+}
+
+/** RSS `<channel>` のうち本スイートで検証に使うフィールド。 */
+export interface RssFeedContent {
+  siteName: string;
+  description: string;
+  language: string;
+  items: RssFeedItem[];
+}
+
+/**
+ * `/rss.xml` エンドポイントのページオブジェクト。
+ *
+ * RSS はブラウザで描画するページではなく XML 応答のため、他の POM とは異なり
+ * `APIRequestContext` で取得した `APIResponse` を介して検証する。
+ * `goto()` でフィードを取得して本文をキャッシュし、`response` でステータスや
+ * ヘッダーを、`content()` でパース結果をそれぞれ spec に提供する。
+ *
+ * XML のパースは XSLT スタイルシートの変換を受けず生の XML を扱うため、
+ * ブラウザの `DOMParser` (`application/xml`) で行う。`@astrojs/rss` は
+ * `Content-Type: application/xml` を返すため、content-type の検証もそれに合わせる。
+ */
+export class RssFeedPage {
+  readonly page: Page;
+  readonly request: APIRequestContext;
+  private _response?: APIResponse;
+  private _xml?: string;
+
+  constructor(page: Page, request: APIRequestContext) {
+    this.page = page;
+    this.request = request;
+  }
+
+  /** `/rss.xml` を取得し、応答と本文をキャッシュする。 */
+  async goto(): Promise<void> {
+    this._response = await this.request.get(routes.rss);
+    this._xml = await this._response.text();
+  }
+
+  /** `goto()` で取得した `APIResponse`。ステータス・ヘッダー検証に使用。 */
+  get response(): APIResponse {
+    if (!this._response) {
+      throw new Error('RssFeedPage.goto() を先に呼び出してください。');
+    }
+    return this._response;
+  }
+
+  /** キャッシュした XML を `DOMParser` でパースした結果を返す。 */
+  async content(): Promise<RssFeedContent> {
+    if (!this._xml) {
+      throw new Error('RssFeedPage.goto() を先に呼び出してください。');
+    }
+    return this.page.evaluate((xml) => {
+      const doc = new DOMParser().parseFromString(xml, 'application/xml');
+      const channel = doc.querySelector('channel');
+      const items = Array.from(doc.querySelectorAll('item')).map((item) => ({
+        title: item.querySelector('title')?.textContent ?? '',
+        link: item.querySelector('link')?.textContent ?? '',
+      }));
+      return {
+        siteName: channel?.querySelector('title')?.textContent ?? '',
+        description: channel?.querySelector('description')?.textContent ?? '',
+        language: channel?.querySelector('language')?.textContent ?? '',
+        items,
+      };
+    }, this._xml);
+  }
+}

--- a/tests/e2e/specs/rss.spec.ts
+++ b/tests/e2e/specs/rss.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '../fixtures/test';
+import { routes, sampleArticleTitle } from '../utils/routes';
+
+/**
+ * `/rss.xml` RSS フィードの E2E 検証。
+ *
+ * RSS はブラウザ描画ではなく XML 応答のため、ビューポートやブラウザエンジンに
+ * 依存しない。重複実行を避けるため Chromium 1 プロジェクトのみで実行する。
+ *
+ * 期待仕様（`src/pages/rss.xml.ts` 参考）:
+ * - `@astrojs/rss` が `Content-Type: application/xml` で応答する。
+ * - `<channel>` に `config.siteName`・`config.description`・`<language>ja-jp</language>` が含まれる。
+ * - 各 `<item>` は `title` と `pubDate` frontmatter を持つ記事のみ（`hasRequiredFrontmatter`）。
+ *   `title` または `pubDate` が未設定の記事（例: 記事テンプレート）はフィードから除外される。
+ *   本リポジトリに draft 扱いは存在せず、上記 frontmatter 条件のみで絞り込む。
+ */
+test.describe('RSS フィード', () => {
+  test.beforeEach(({ browserName }) => {
+    test.skip(
+      browserName !== 'chromium',
+      'XML 応答ベースの検証のため Chromium 1 プロジェクトのみで実行',
+    );
+  });
+
+  test.beforeEach(async ({ rssFeedPage }) => {
+    await rssFeedPage.goto();
+  });
+
+  test('/rss.xml が 200 で XML の content-type を返す', async ({
+    rssFeedPage,
+  }) => {
+    expect(rssFeedPage.response.status()).toBe(200);
+    expect(rssFeedPage.response.headers()['content-type']).toMatch(/xml/i);
+  });
+
+  test('チャネルにサイト名と説明と言語が含まれる', async ({ rssFeedPage }) => {
+    const feed = await rssFeedPage.content();
+
+    expect(feed.siteName).toBe('Daiki Sato');
+    expect(feed.description).toBe('Daiki Satoのブログ');
+    expect(feed.language).toBe('ja-jp');
+  });
+
+  test('代表記事のタイトルとリンクが含まれる', async ({ rssFeedPage }) => {
+    const feed = await rssFeedPage.content();
+
+    const sample = feed.items.find((item) => item.title === sampleArticleTitle);
+    expect(sample).toBeTruthy();
+    // ホスト・末尾スラッシュの差異に依存しないようパスで部分一致させる。
+    expect(sample?.link).toContain(routes.sampleArticle);
+  });
+
+  test('frontmatter 不足の記事はフィードから除外される', async ({
+    rssFeedPage,
+  }) => {
+    const { items } = await rssFeedPage.content();
+
+    expect(items.length).toBeGreaterThan(0);
+    // hasRequiredFrontmatter (title + pubDate) を通過した記事だけが並ぶため、
+    // 全 item が title・link を持つ。
+    for (const item of items) {
+      expect(item.title).not.toBe('');
+      expect(item.link).not.toBe('');
+    }
+    // 記事テンプレート (title 未設定) はフィードに出現しない。
+    expect(items.some((item) => item.link.includes('/template/'))).toBe(false);
+  });
+});

--- a/tests/e2e/utils/routes.ts
+++ b/tests/e2e/utils/routes.ts
@@ -8,6 +8,7 @@ export const routes = {
   home: '/',
   about: '/about',
   sampleArticle: '/posts/audio-interface-under-the-desk',
+  rss: '/rss.xml',
 } as const;
 
 /**


### PR DESCRIPTION
Closes #571

## 概要
issue #571 の RSS フィード E2E カバレッジを追加。

## 追加した検証 (`tests/e2e/specs/rss.spec.ts`)
- `/rss.xml` が 200 で XML 系 content-type (`application/xml`) を返す
- `<channel>` にサイト名・説明・言語 (`ja-jp`) が含まれる
- 代表記事のタイトルとリンクが `<item>` に含まれる
- frontmatter 不足記事 (`title`/`pubDate` 未設定) はフィードから除外される（本リポジトリに draft 扱いはなく、`hasRequiredFrontmatter` 条件のみで絞り込み）

## 構成
- `RssFeedPage` POM と `rssFeedPage` fixture を追加（`APIRequestContext` で取得→`DOMParser` でパース）
- XML 応答ベースのため Chromium 1 プロジェクトのみで実行（それ以外は skip）

## 検証
- `pnpm run lint`: 0 errors
- `pnpm exec playwright test tests/e2e/specs/rss.spec.ts --project=chromium`: 4 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for the site’s RSS feed, including checks for feed availability, XML response format, channel metadata, and article entries.
* **Bug Fixes**
  * Ensured pages missing required article details are excluded from the RSS feed.
  * Verified template-related links do not appear in feed results.
* **Documentation**
  * Updated testing documentation to include the new RSS feed test flow and related setup details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->