### PR TITLE
test(e2e): raw Markdown エンドポイントの E2E テストを追加

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -52,7 +52,8 @@ tests/e2e/
     ├── smoke.spec.ts         # 基本表示の確認
     ├── navigation.spec.ts    # ヘッダー/フッターの遷移確認
     ├── theme.spec.ts         # テーマ切り替えの確認
-    └── visual.spec.ts        # ビジュアルリグレッション
+    ├── visual.spec.ts        # ビジュアルリグレッション
+    └── raw-markdown.spec.ts  # raw Markdown エンドポイント
 ```
 
 ビジュアルスナップショットは `tests/e2e/specs/visual.spec.ts-snapshots/` に保存します。`snapshotPathTemplate` で OS サフィックスを外し、プロジェクト名だけを付けます。例: `article-metadata-chromium.png`
@@ -170,6 +171,18 @@ pnpm run test:e2e:update
 # 個別 spec のみ更新する場合
 pnpm exec playwright test tests/e2e/specs/visual.spec.ts --update-snapshots
 ```
+
+### raw Markdown エンドポイント (`raw-markdown.spec.ts`)
+
+`/posts/[slug].md` の raw Markdown エンドポイントを `astro preview` 経由で検証します（実装: `src/pages/posts/[slug].md.ts`、仕様: `docs/raw-markdown-endpoints.md`）。Playwright の `request` fixture を使い、HTTP ステータス・`Content-Type`・本文を直接アサーションします。
+
+- 代表記事の `.md` URL が `200` を返す
+- `Content-Type` が `text/markdown` で始まる
+  - 本番（Cloudflare Workers Static Assets）では `text/markdown; charset=utf-8` になりますが、`astro preview` は `text/markdown` のみを返すため、spec では `text/markdown` であることだけを検証します。`charset=utf-8` の厳密検証は Workers プレビューが必要なため別途切り出します。
+- frontmatter（`title` / `description`）と本文が含まれる
+- Astro 表示用の `layout` frontmatter は除去されている（`^layout:` 行が存在しない）
+
+通常記事 URL + `Accept: text/markdown` による content negotiation は `src/worker.ts` で実装されており Workers プレビュー側でのみ機能します。`astro preview` では Worker を経由しないため本 spec ではカバーせず、別 Issue で取り扱います。
 
 ## GitHub Actions
 

--- a/tests/e2e/specs/raw-markdown.spec.ts
+++ b/tests/e2e/specs/raw-markdown.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '../fixtures/test';
+import {
+  routes,
+  sampleArticleDescription,
+  sampleArticleTitle,
+} from '../utils/routes';
+
+/**
+ * `/posts/[slug].md` raw Markdown エンドポイントの E2E テスト。
+ *
+ * Astro の静的ビルドで `/posts/[slug].md` が生成され、`astro preview` から配信される。
+ * 実装は `src/pages/posts/[slug].md.ts`、仕様は `docs/raw-markdown-endpoints.md` 参照。
+ *
+ * `Content-Type` は本番（Cloudflare Workers Static Assets）では
+ * `text/markdown; charset=utf-8` になるが、E2E で使う `astro preview` は
+ * `text/markdown` のみを返す。そのため charset 部分は厳密に検証せず、
+ * `text/markdown` であることだけを確認する（charset の厳密検証は Workers
+ * プレビューが必要なため別途切り出す）。
+ *
+ * 通常記事 URL + `Accept: text/markdown` による content negotiation は
+ * `src/worker.ts` で実装されており、Workers プレビュー側でのみ機能する。
+ * `astro preview` では Worker を経由しないため本 spec の対象外とし、別 Issue で扱う。
+ */
+test.describe('raw Markdown エンドポイント', () => {
+  test('代表記事の .md URL が raw Markdown を返す', async ({ request }) => {
+    const response = await request.get(routes.sampleArticleMarkdown);
+
+    // 200 OK
+    expect(response.status()).toBe(200);
+
+    // Content-Type が Markdown であること
+    expect(response.headers()['content-type'] ?? '').toMatch(
+      /^text\/markdown\b/,
+    );
+
+    const body = await response.text();
+
+    // frontmatter を含むこと
+    expect(body.startsWith('---\n')).toBe(true);
+    expect(body).toContain(`title: ${sampleArticleTitle}`);
+    expect(body).toContain(`description: ${sampleArticleDescription}`);
+
+    // 本文を含むこと（frontmatter 終端の後に本体がある）
+    const closingFrontmatterIndex = body.indexOf('\n---', 4);
+    expect(closingFrontmatterIndex).toBeGreaterThan(-1);
+    const articleBody = body.slice(closingFrontmatterIndex + '\n---'.length);
+    expect(articleBody.trim().length).toBeGreaterThan(0);
+
+    // Astro 表示用の `layout` frontmatter は除去されていること
+    expect(body).not.toMatch(/^layout:/m);
+  });
+});

--- a/tests/e2e/utils/routes.ts
+++ b/tests/e2e/utils/routes.ts
@@ -8,13 +8,23 @@ export const routes = {
   home: '/',
   about: '/about',
   sampleArticle: '/posts/audio-interface-under-the-desk',
+  /** `routes.sampleArticle` の raw Markdown エンドポイント。 */
+  sampleArticleMarkdown: '/posts/audio-interface-under-the-desk.md',
 } as const;
 
 /**
  * `routes.sampleArticle` が参照するサンプル記事のタイトル。
  *
- * セマンティックロケーター（`getByRole('link', { name: ... })`）や
+ * セマンティックロケーター（`getByRole('link', { name: ... }`）や
  * タイトルアサーションに使用し、spec が DOM 構造に依存しないようにする。
  */
 export const sampleArticleTitle =
   'オーディオインターフェースを机の裏に設置した';
+
+/**
+ * `routes.sampleArticle` の frontmatter `description`。
+ *
+ * raw Markdown エンドポイントが frontmatter を含めて返すことを検証するために使用する。
+ */
+export const sampleArticleDescription =
+  'オーディオインターフェースを両面テープで机の下に設置するために、突っ張り棒を使って仮固定しました。';


### PR DESCRIPTION
Closes #570

## 概要
`/posts/[slug].md` raw Markdown エンドポイント (`src/pages/posts/[slug].md.ts`) に対する E2E テストを追加。

## 検証内容 (`tests/e2e/specs/raw-markdown.spec.ts`)
- 代表記事の `.md` URL が `200` を返す
- `Content-Type` が `text/markdown` で始まる
- frontmatter (`title` / `description`) と本文が含まれる
- Astro 表示用 `layout` frontmatter が除去されている (`^layout:` 行なし)

## 対象外（別 Issue 想定）
- `Content-Type: text/markdown; charset=utf-8` の厳密検証: 本番 (Workers Static Assets) では付与されるが `astro preview` では付与されないため、Workers プレビューが必要。
- 通常記事 URL + `Accept: text/markdown` の content negotiation: `src/worker.ts` で実装されており Workers プレビュー側でのみ機能。

## 検証
- `pnpm run lint` / `pnpm run format:check`: pass
- `pnpm exec playwright test tests/e2e/specs/raw-markdown.spec.ts`: 6 プロジェクト全 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for testing the raw Markdown endpoint in end-to-end coverage notes.
  * Updated the E2E spec list to include the new Markdown-focused test.

* **Tests**
  * Added a new end-to-end test for article `.md` URLs.
  * Verifies the response returns Markdown content, includes expected frontmatter and body content, and omits unsupported frontmatter fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->