### PR TITLE
ci: use default E2E workers and GitHub reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
     name: E2E tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      E2E_WORKERS: '2'
 
     steps:
       - *checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,6 @@ jobs:
     name: E2E tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      E2E_WORKERS: '2'
 
     steps:
       - *checkout

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -72,6 +72,7 @@ tests/e2e/
 - `webServer`: `pnpm run build:ci && pnpm run preview --port 4322` でプレビューサーバーを起動し、E2E 専用の `http://localhost:4322/` の応答を待ってからテストを開始します。通常の開発サーバーが使う `4321` とは競合しません。
 - `build:ci`: `prebuild` による `pnpm lint` の再実行を避けるため、E2E では通常の `build` ではなく `build:ci` を使います。
 - `reporter`: `list` で標準出力に進行を出し、`html` で `playwright-report/` を生成します。
+- `fullyParallel`: spec 内のテストも並列化します。CI では `E2E_WORKERS` 環境変数でワーカー数を指定し、未指定・不正値の場合も 2 ワーカーで実行します。
 - `projects`: デスクトップ 3 種（`chromium` / `firefox` / `webkit`）とモバイル 3 種（`Mobile Chrome` / `Mobile Safari` / `Mobile Safari (Small screen)`）を定義します。
 - 失敗時の調査用に `trace: 'on-first-retry'`、`screenshot: 'only-on-failure'`、`video: 'retain-on-failure'` を有効にしています。
 - `baseURL`: E2E 専用の `http://localhost:4322/` に揃え、spec では `page.goto('/about')` のような相対パスを使います。
@@ -251,7 +252,7 @@ pnpm exec playwright test tests/e2e/specs/visual.spec.ts --update-snapshots
 
 1. `fonts-noto-cjk` をインストールし、スクリーンショット用の日本語フォントを固定する。
 2. `pnpm exec playwright install --with-deps chromium firefox webkit` で全ブラウザと必要なシステム依存パッケージをインストールする（config が 6 プロジェクトを定義するため、Firefox / WebKit も必要）。
-3. `pnpm run test:e2e` を実行する。
+3. `E2E_WORKERS=2` を指定した状態で `pnpm run test:e2e` を実行する。`playwright.config.ts` では `fullyParallel: true` と組み合わせ、CI でも複数ワーカーで spec 内テストを並列実行する。
 4. `playwright-report/` と `test-results/` を artifact としてアップロードする。
 
 artifact の保持期間は 7 日です。テストが失敗した場合も調査できるよう、アップロードステップには `if: ${{ !cancelled() }}` を付けています。

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -71,7 +71,7 @@ tests/e2e/
 - `testDir`: `./tests/e2e/specs` を指定し、spec ファイルだけをテスト対象にします。
 - `webServer`: `pnpm run build:ci && pnpm run preview --port 4322` でプレビューサーバーを起動し、E2E 専用の `http://localhost:4322/` の応答を待ってからテストを開始します。通常の開発サーバーが使う `4321` とは競合しません。
 - `build:ci`: `prebuild` による `pnpm lint` の再実行を避けるため、E2E では通常の `build` ではなく `build:ci` を使います。
-- `reporter`: `list` で標準出力に進行を出し、`html` で `playwright-report/` を生成します。
+- `reporter`: 通常は `list` で標準出力に進行を出し、`html` で `playwright-report/` を生成します。GitHub Actions 上では `github` reporter も追加し、失敗箇所を Actions の annotation として表示します。
 - `fullyParallel`: spec 内のテストも並列化します。`workers` は常に `undefined` とし、Playwright のデフォルト（論理 CPU コア数の半分）に任せます。
 - `projects`: デスクトップ 3 種（`chromium` / `firefox` / `webkit`）とモバイル 3 種（`Mobile Chrome` / `Mobile Safari` / `Mobile Safari (Small screen)`）を定義します。
 - 失敗時の調査用に `trace: 'on-first-retry'`、`screenshot: 'only-on-failure'`、`video: 'retain-on-failure'` を有効にしています。
@@ -252,7 +252,7 @@ pnpm exec playwright test tests/e2e/specs/visual.spec.ts --update-snapshots
 
 1. `fonts-noto-cjk` をインストールし、スクリーンショット用の日本語フォントを固定する。
 2. `pnpm exec playwright install --with-deps chromium firefox webkit` で全ブラウザと必要なシステム依存パッケージをインストールする（config が 6 プロジェクトを定義するため、Firefox / WebKit も必要）。
-3. `pnpm run test:e2e` を実行する。`playwright.config.ts` では `fullyParallel: true` と `workers: undefined` を組み合わせ、Playwright のデフォルト worker 数で spec 内テストを並列実行する。
+3. `pnpm run test:e2e` を実行する。`playwright.config.ts` では `fullyParallel: true` と `workers: undefined` を組み合わせ、Playwright のデフォルト worker 数で spec 内テストを並列実行する。GitHub Actions 上では `github` reporter を `list` / `html` に追加し、失敗時の annotation を有効化する。
 4. `playwright-report/` と `test-results/` を artifact としてアップロードする。
 
 artifact の保持期間は 7 日です。テストが失敗した場合も調査できるよう、アップロードステップには `if: ${{ !cancelled() }}` を付けています。

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -72,7 +72,7 @@ tests/e2e/
 - `webServer`: `pnpm run build:ci && pnpm run preview --port 4322` でプレビューサーバーを起動し、E2E 専用の `http://localhost:4322/` の応答を待ってからテストを開始します。通常の開発サーバーが使う `4321` とは競合しません。
 - `build:ci`: `prebuild` による `pnpm lint` の再実行を避けるため、E2E では通常の `build` ではなく `build:ci` を使います。
 - `reporter`: `list` で標準出力に進行を出し、`html` で `playwright-report/` を生成します。
-- `fullyParallel`: spec 内のテストも並列化します。CI では `E2E_WORKERS` 環境変数でワーカー数を指定し、未指定・不正値の場合も 2 ワーカーで実行します。
+- `fullyParallel`: spec 内のテストも並列化します。`workers` は常に `undefined` とし、Playwright のデフォルト（論理 CPU コア数の半分）に任せます。
 - `projects`: デスクトップ 3 種（`chromium` / `firefox` / `webkit`）とモバイル 3 種（`Mobile Chrome` / `Mobile Safari` / `Mobile Safari (Small screen)`）を定義します。
 - 失敗時の調査用に `trace: 'on-first-retry'`、`screenshot: 'only-on-failure'`、`video: 'retain-on-failure'` を有効にしています。
 - `baseURL`: E2E 専用の `http://localhost:4322/` に揃え、spec では `page.goto('/about')` のような相対パスを使います。
@@ -252,7 +252,7 @@ pnpm exec playwright test tests/e2e/specs/visual.spec.ts --update-snapshots
 
 1. `fonts-noto-cjk` をインストールし、スクリーンショット用の日本語フォントを固定する。
 2. `pnpm exec playwright install --with-deps chromium firefox webkit` で全ブラウザと必要なシステム依存パッケージをインストールする（config が 6 プロジェクトを定義するため、Firefox / WebKit も必要）。
-3. `E2E_WORKERS=2` を指定した状態で `pnpm run test:e2e` を実行する。`playwright.config.ts` では `fullyParallel: true` と組み合わせ、CI でも複数ワーカーで spec 内テストを並列実行する。
+3. `pnpm run test:e2e` を実行する。`playwright.config.ts` では `fullyParallel: true` と `workers: undefined` を組み合わせ、Playwright のデフォルト worker 数で spec 内テストを並列実行する。
 4. `playwright-report/` と `test-results/` を artifact としてアップロードする。
 
 artifact の保持期間は 7 日です。テストが失敗した場合も調査できるよう、アップロードステップには `if: ${{ !cancelled() }}` を付けています。

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig, devices } from '@playwright/test';
 const e2ePort = 4322;
 const e2eBaseURL = `http://localhost:${e2ePort}/`;
+const ciE2EWorkers = (() => {
+  if (!process.env.CI) {
+    return undefined;
+  }
+
+  const parsedWorkers = Number.parseInt(process.env.E2E_WORKERS ?? '2', 10);
+
+  return Number.isFinite(parsedWorkers) && parsedWorkers > 1
+    ? parsedWorkers
+    : 2;
+})();
 
 /**
  * Astro ブログの Playwright E2E 設定。
@@ -17,7 +28,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: ciE2EWorkers,
   reporter: [['list'], ['html']],
   use: {
     baseURL: e2eBaseURL,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: undefined,
-  reporter: [['list'], ['html']],
+  reporter: process.env.GITHUB_ACTIONS
+    ? [['github'], ['list'], ['html']]
+    : [['list'], ['html']],
   use: {
     baseURL: e2eBaseURL,
     trace: 'on-first-retry',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,17 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
 const e2ePort = 4322;
 const e2eBaseURL = `http://localhost:${e2ePort}/`;
-const ciE2EWorkers = (() => {
-  if (!process.env.CI) {
-    return undefined;
-  }
-
-  const parsedWorkers = Number.parseInt(process.env.E2E_WORKERS ?? '2', 10);
-
-  return Number.isFinite(parsedWorkers) && parsedWorkers > 1
-    ? parsedWorkers
-    : 2;
-})();
 
 /**
  * Astro ブログの Playwright E2E 設定。
@@ -28,7 +17,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: ciE2EWorkers,
+  workers: undefined,
   reporter: [['list'], ['html']],
   use: {
     baseURL: e2eBaseURL,


### PR DESCRIPTION
## Summary
- Set Playwright `workers` to `undefined` at all times so the runner uses Playwright's default worker count
- Add Playwright's built-in `github` reporter on GitHub Actions while keeping existing `list` and `html` reporters
- Update the E2E docs to describe default worker behavior and GitHub Actions annotations

## Test Plan
- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [x] `CI=1 GITHUB_ACTIONS=true pnpm run test:e2e` (`Running 162 tests using 2 workers`, 146 passed / 16 skipped; GitHub reporter emitted a Playwright Run Summary notice)