### PR TITLE
test(e2e): expectのmessageを整備

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -123,6 +123,7 @@ export const sampleArticleDescription =
 - POM は薄く保ちます。ロケーターと小さな操作だけを公開し、検証は spec 側に書きます。
 - role、アクセシブル名、表示テキストなど、ユーザーに近いセマンティックロケーターを優先します。
 - `data-testid` は最後の手段です。現時点ではアプリ側にテスト専用属性を追加しません。
+- すべての `expect` に期待する状態・結果を具体的に表す日本語の custom message を付けます。通常は `expect(actual, message)`、`expect.poll` は options の `message` を使います。詳しくは Playwright 公式の [Custom expect message](https://playwright.dev/docs/test-assertions#custom-expect-message) を参照してください。
 
 ### コンポーネント (`tests/e2e/components/`)
 

--- a/docs/superpowers/plans/2026-06-30-e2e-expect-messages.md
+++ b/docs/superpowers/plans/2026-06-30-e2e-expect-messages.md
@@ -1,0 +1,160 @@
+# E2E expect Messages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `tests/e2e/` 配下のすべての Playwright `expect` に、レポートで期待内容を判別できるカスタムメッセージを設定する。
+
+**Architecture:** 各アサーションの呼び出し位置に日本語のメッセージを直接置き、期待結果とレポート表示を同じ場所で保守する。通常の `expect` は第二引数、`expect.poll` は第二引数の options object にある `message` を使用し、共通ラッパーは追加しない。
+
+**Tech Stack:** TypeScript、Playwright Test、pnpm、ESLint、Astro
+
+---
+
+### Task 1: 全 E2E expect にカスタムメッセージを追加する
+
+**Files:**
+
+- Modify: `tests/e2e/components/header.ts`
+- Modify: `tests/e2e/specs/accessibility.spec.ts`
+- Modify: `tests/e2e/specs/navigation.spec.ts`
+- Modify: `tests/e2e/specs/not-found.spec.ts`
+- Modify: `tests/e2e/specs/raw-markdown.spec.ts`
+- Modify: `tests/e2e/specs/rss.spec.ts`
+- Modify: `tests/e2e/specs/smoke.spec.ts`
+- Modify: `tests/e2e/specs/tag.spec.ts`
+- Modify: `tests/e2e/specs/theme.spec.ts`
+- Modify: `tests/e2e/specs/toc.spec.ts`
+- Modify: `tests/e2e/specs/visual.spec.ts`
+- Modify: `docs/e2e-testing.md`
+
+- [ ] **Step 1: AST ガードを実行し、メッセージ未設定で失敗することを確認する**
+
+次の一時チェックを実行する。通常の `expect` は引数が2個以上、`expect.poll` は第二引数が object literal かつ `message` property を持つことを要求する。
+
+```bash
+node --input-type=module <<'NODE'
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const root = 'tests/e2e';
+const files = [];
+const walk = (directory) => {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const target = path.join(directory, entry.name);
+    if (entry.isDirectory()) walk(target);
+    else if (entry.isFile() && target.endsWith('.ts')) files.push(target);
+  }
+};
+walk(root);
+
+const missing = [];
+for (const file of files) {
+  const source = ts.createSourceFile(
+    file,
+    fs.readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const visit = (node) => {
+    if (ts.isCallExpression(node)) {
+      const directExpect = ts.isIdentifier(node.expression) && node.expression.text === 'expect';
+      const pollExpect =
+        ts.isPropertyAccessExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) &&
+        node.expression.expression.text === 'expect' &&
+        node.expression.name.text === 'poll';
+      if (directExpect && node.arguments.length < 2) {
+        missing.push(`${file}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1} expect second argument`);
+      }
+      if (pollExpect) {
+        const options = node.arguments[1];
+        const hasMessage =
+          options &&
+          ts.isObjectLiteralExpression(options) &&
+          options.properties.some(
+            (property) =>
+              ts.isPropertyAssignment(property) &&
+              ((ts.isIdentifier(property.name) && property.name.text === 'message') ||
+                (ts.isStringLiteral(property.name) && property.name.text === 'message')),
+          );
+        if (!hasMessage) {
+          missing.push(`${file}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1} expect.poll message option`);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+}
+
+if (missing.length > 0) {
+  console.error(missing.join('\n'));
+  process.exit(1);
+}
+console.log('All Playwright expect calls under tests/e2e have custom messages.');
+NODE
+```
+
+Expected: `tests/e2e/... expect second argument` と `expect.poll message option` が列挙され、exit code 1 で失敗する。
+
+- [ ] **Step 2: 各 expect に最小限で具体的なメッセージを追加する**
+
+通常のアサーションは次の形にする。
+
+```typescript
+await expect(page, 'Blog リンクからホームページに遷移する').toHaveURL(
+  HOME_URL_REGEX,
+);
+```
+
+ポーリングは次の形にする。
+
+```typescript
+await expect
+  .poll(() => page.evaluate(() => localStorage.getItem('theme')), {
+    message: 'ダークテーマ選択後は theme に dark が保存される',
+  })
+  .toBe('dark');
+```
+
+ループ内の汎用アサーションは対象値を含める。
+
+```typescript
+expect(item.title, `RSS item (${item.link}) のタイトルが空でない`).not.toBe(
+  '',
+);
+```
+
+`docs/e2e-testing.md` の POM 方針付近に、全 `expect` へ期待結果を表すカスタムメッセージを付け、`expect.poll` では options の `message` を使う運用ルールと公式 Assertions へのリンクを追記する。
+
+- [ ] **Step 3: AST ガードを再実行して通過を確認する**
+
+Step 1 と同じコマンドを実行する。
+
+Expected: `All Playwright expect calls under tests/e2e have custom messages.` と表示され、exit code 0。
+
+- [ ] **Step 4: lint と E2E 全体を実行する**
+
+```bash
+pnpm run lint
+pnpm run test:e2e
+```
+
+Expected: lint が exit code 0。E2E は 152 passed / 28 skipped、0 failed。
+
+- [ ] **Step 5: 差分を自己レビューしてコミットする**
+
+```bash
+git diff --check
+git diff -- tests/e2e docs/e2e-testing.md
+git add tests/e2e docs/e2e-testing.md
+git commit -m "test: E2E expectに説明メッセージを追加"
+```
+
+コミットには次の trailer を1回だけ含める。
+
+```text
+Co-authored-by: Codex <noreply@openai.com>
+```

--- a/docs/superpowers/specs/2026-06-30-e2e-expect-messages-design.md
+++ b/docs/superpowers/specs/2026-06-30-e2e-expect-messages-design.md
@@ -1,0 +1,32 @@
+# E2E expect メッセージ設計
+
+## 目的
+
+`tests/e2e/` 配下のすべての Playwright `expect` に、アサーションの意図を示すカスタムメッセージを設定する。HTML レポートや失敗ログだけを見ても、どの期待結果を検証しているか判断できる状態にする。
+
+## 採用方針
+
+各 `expect` 呼び出しの近くにメッセージを直接記述する。共通ラッパーやメッセージ辞書は導入しない。直接記述なら、テストの期待結果とレポートの表示名を同じ場所で読め、変更対象も E2E コード内に限定できる。
+
+- 通常の `expect(actual)` は `expect(actual, message)` にする。
+- `expect.poll(callback)` は API 仕様に従い `expect.poll(callback, { message })` にする。
+- メッセージは日本語の肯定形で、期待する状態または結果を具体的に表す。
+- 同じテスト内で似たアサーションが続く場合は、初期状態・操作後・再読込後などの文脈を含めて区別する。
+- ループ内では、失敗対象を特定できる範囲で記事タイトルやリンクなどの動的値を含める。
+- matcher 名や実装詳細をそのまま読み上げるだけの曖昧な文言は避ける。
+
+Playwright 公式ドキュメントでは、カスタムメッセージは成功・失敗の両方で reporter に表示され、より多くの文脈を与える用途とされている。また、`expect.poll` のメッセージは options の `message` で指定する。
+
+## 対象
+
+`tests/e2e/` 配下で Playwright の `expect` を呼ぶ TypeScript ファイルをすべて対象にする。spec に加え、モバイルメニューの状態待機を行う `tests/e2e/components/header.ts` も含む。既にメッセージを持つアクセシビリティ検査も、全体の文体に合わせて意図が明確か確認する。
+
+## 検証
+
+TypeScript AST を使った一時チェックで、通常の `expect` に第二引数があること、`expect.poll` に `message` option があることを機械的に確認する。続いて `pnpm run lint` と `pnpm run test:e2e` を実行し、型・書式・全ブラウザで既存の挙動が変わっていないことを確認する。
+
+## 参考資料
+
+- [Playwright Assertions: Custom expect message](https://playwright.dev/docs/test-assertions#custom-expect-message)
+- [Playwright Assertions: expect.poll](https://playwright.dev/docs/test-assertions#expectpoll)
+- [Playwright Best Practices: Use web first assertions](https://playwright.dev/docs/best-practices#use-web-first-assertions)

--- a/tests/e2e/components/header.ts
+++ b/tests/e2e/components/header.ts
@@ -69,7 +69,10 @@ export class Header {
   async openMobileMenu(): Promise<void> {
     if ((await this.hamburger.getAttribute('aria-expanded')) !== 'true') {
       await this.hamburger.click();
-      await expect(this.hamburger).toHaveAttribute('aria-expanded', 'true');
+      await expect(
+        this.hamburger,
+        'モバイルメニューを開くとハンバーガーボタンの aria-expanded が true になる',
+      ).toHaveAttribute('aria-expanded', 'true');
     }
 
     await this.root.evaluate(async (header) => {

--- a/tests/e2e/specs/accessibility.spec.ts
+++ b/tests/e2e/specs/accessibility.spec.ts
@@ -82,7 +82,7 @@ async function scanPageForAccessibility({
 
   expect(
     blockingViolations,
-    'seriousまたはcriticalのアクセシビリティ違反',
+    'serious または critical のアクセシビリティ違反が存在しない',
   ).toEqual([]);
 }
 

--- a/tests/e2e/specs/navigation.spec.ts
+++ b/tests/e2e/specs/navigation.spec.ts
@@ -21,7 +21,10 @@ test.describe('ナビゲーション', () => {
     }
     await aboutPage.header.blogLink.click();
 
-    await expect(page).toHaveURL(HOME_URL_REGEX);
+    await expect(
+      page,
+      'ヘッダーの Blog リンクからホームページに遷移する',
+    ).toHaveURL(HOME_URL_REGEX);
   });
 
   test('ヘッダーの About リンクで About に遷移する', async ({
@@ -35,7 +38,10 @@ test.describe('ナビゲーション', () => {
     }
     await homePage.header.aboutLink.click();
 
-    await expect(page).toHaveURL(/\/about\/?$/);
+    await expect(
+      page,
+      'ヘッダーの About リンクから About ページに遷移する',
+    ).toHaveURL(/\/about\/?$/);
   });
 
   test('フッターの Blog リンクでホームに遷移する', async ({
@@ -43,10 +49,16 @@ test.describe('ナビゲーション', () => {
     page,
   }) => {
     await aboutPage.goto();
-    await expect(aboutPage.footer.rssLink).toBeVisible();
+    await expect(
+      aboutPage.footer.rssLink,
+      'About ページのフッターに RSS feed リンクが表示される',
+    ).toBeVisible();
     await aboutPage.footer.blogLink.click();
 
-    await expect(page).toHaveURL(HOME_URL_REGEX);
+    await expect(
+      page,
+      'フッターの Blog リンクからホームページに遷移する',
+    ).toHaveURL(HOME_URL_REGEX);
   });
 
   test('フッターの About リンクで About に遷移する', async ({
@@ -56,6 +68,9 @@ test.describe('ナビゲーション', () => {
     await homePage.goto();
     await homePage.footer.aboutLink.click();
 
-    await expect(page).toHaveURL(/\/about\/?$/);
+    await expect(
+      page,
+      'フッターの About リンクから About ページに遷移する',
+    ).toHaveURL(/\/about\/?$/);
   });
 });

--- a/tests/e2e/specs/not-found.spec.ts
+++ b/tests/e2e/specs/not-found.spec.ts
@@ -13,22 +13,32 @@ test.describe('404 ページ', () => {
     const response = await notFoundPage.goto();
 
     // 404 ステータスであることを検証する。
-    expect(response?.status()).toBe(404);
+    expect(response?.status(), '存在しない URL は HTTP 404 を返す').toBe(404);
 
     // ページタイトルと主要な見出しが期待どおりであることを確認する。
-    await expect(notFoundPage.page).toHaveTitle(
-      /404: Page Not Found.*Daiki Sato/,
-    );
-    await expect(notFoundPage.heading).toBeVisible();
+    await expect(
+      notFoundPage.page,
+      '404 ページのタイトルに Page Not Found とサイト名が含まれる',
+    ).toHaveTitle(/404: Page Not Found.*Daiki Sato/);
+    await expect(
+      notFoundPage.heading,
+      '404 ページに主要見出しが表示される',
+    ).toBeVisible();
   });
 
   test('ホームに戻るリンクでホームに遷移する', async ({ notFoundPage }) => {
     await notFoundPage.goto();
 
     // 導線が存在することを確認してからクリックで遷移を検証する。
-    await expect(notFoundPage.homeLink).toBeVisible();
+    await expect(
+      notFoundPage.homeLink,
+      '404 ページにホームへ戻るリンクが表示される',
+    ).toBeVisible();
     await notFoundPage.homeLink.click();
 
-    await expect(notFoundPage.page).toHaveURL(HOME_URL_REGEX);
+    await expect(
+      notFoundPage.page,
+      'ホームへ戻るリンクからホームページに遷移する',
+    ).toHaveURL(HOME_URL_REGEX);
   });
 });

--- a/tests/e2e/specs/raw-markdown.spec.ts
+++ b/tests/e2e/specs/raw-markdown.spec.ts
@@ -26,27 +26,49 @@ test.describe('raw Markdown エンドポイント', () => {
     const response = await request.get(routes.sampleArticleMarkdown);
 
     // 200 OK
-    expect(response.status()).toBe(200);
+    expect(
+      response.status(),
+      '代表記事の raw Markdown URL は HTTP 200 を返す',
+    ).toBe(200);
 
     // Content-Type が Markdown であること
-    expect(response.headers()['content-type'] ?? '').toMatch(
-      /^text\/markdown\b/,
-    );
+    expect(
+      response.headers()['content-type'] ?? '',
+      '代表記事の raw Markdown 応答は text/markdown を返す',
+    ).toMatch(/^text\/markdown\b/);
 
     const body = await response.text();
 
     // frontmatter を含むこと
-    expect(body.startsWith('---\n')).toBe(true);
-    expect(body).toContain(`title: ${sampleArticleTitle}`);
-    expect(body).toContain(`description: ${sampleArticleDescription}`);
+    expect(
+      body.startsWith('---\n'),
+      'raw Markdown は frontmatter で始まる',
+    ).toBe(true);
+    expect(
+      body,
+      `raw Markdown の frontmatter に記事タイトル「${sampleArticleTitle}」が含まれる`,
+    ).toContain(`title: ${sampleArticleTitle}`);
+    expect(
+      body,
+      'raw Markdown の frontmatter に代表記事の description が含まれる',
+    ).toContain(`description: ${sampleArticleDescription}`);
 
     // 本文を含むこと（frontmatter 終端の後に本体がある）
     const closingFrontmatterIndex = body.indexOf('\n---', 4);
-    expect(closingFrontmatterIndex).toBeGreaterThan(-1);
+    expect(
+      closingFrontmatterIndex,
+      'raw Markdown に frontmatter の終端が含まれる',
+    ).toBeGreaterThan(-1);
     const articleBody = body.slice(closingFrontmatterIndex + '\n---'.length);
-    expect(articleBody.trim().length).toBeGreaterThan(0);
+    expect(
+      articleBody.trim().length,
+      'frontmatter の後に記事本文が含まれる',
+    ).toBeGreaterThan(0);
 
     // Astro 表示用の `layout` frontmatter は除去されていること
-    expect(body).not.toMatch(/^layout:/m);
+    expect(
+      body,
+      'raw Markdown の frontmatter から Astro 表示用の layout が除去される',
+    ).not.toMatch(/^layout:/m);
   });
 });

--- a/tests/e2e/specs/rss.spec.ts
+++ b/tests/e2e/specs/rss.spec.ts
@@ -29,25 +29,43 @@ test.describe('RSS フィード', () => {
   test('/rss.xml が 200 で XML の content-type を返す', async ({
     rssFeedPage,
   }) => {
-    expect(rssFeedPage.response.status()).toBe(200);
-    expect(rssFeedPage.response.headers()['content-type']).toMatch(/xml/i);
+    expect(
+      rssFeedPage.response.status(),
+      'RSS フィード URL は HTTP 200 を返す',
+    ).toBe(200);
+    expect(
+      rssFeedPage.response.headers()['content-type'],
+      'RSS フィード応答の content-type は XML 形式である',
+    ).toMatch(/xml/i);
   });
 
   test('チャネルにサイト名と説明と言語が含まれる', async ({ rssFeedPage }) => {
     const feed = await rssFeedPage.content();
 
-    expect(feed.siteName).toBe('Daiki Sato');
-    expect(feed.description).toBe('Daiki Satoのブログ');
-    expect(feed.language).toBe('ja-jp');
+    expect(feed.siteName, 'RSS チャネルにサイト名が設定される').toBe(
+      'Daiki Sato',
+    );
+    expect(feed.description, 'RSS チャネルにサイトの説明が設定される').toBe(
+      'Daiki Satoのブログ',
+    );
+    expect(feed.language, 'RSS チャネルの言語が日本語に設定される').toBe(
+      'ja-jp',
+    );
   });
 
   test('代表記事のタイトルとリンクが含まれる', async ({ rssFeedPage }) => {
     const feed = await rssFeedPage.content();
 
     const sample = feed.items.find((item) => item.title === sampleArticleTitle);
-    expect(sample).toBeTruthy();
+    expect(
+      sample,
+      `RSS フィードに代表記事「${sampleArticleTitle}」が含まれる`,
+    ).toBeTruthy();
     // ホスト・末尾スラッシュの差異に依存しないようパスで部分一致させる。
-    expect(sample?.link).toContain(routes.sampleArticle);
+    expect(
+      sample?.link,
+      `RSS フィードの代表記事リンクにパス「${routes.sampleArticle}」が含まれる`,
+    ).toContain(routes.sampleArticle);
   });
 
   test('frontmatter 不足の記事はフィードから除外される', async ({
@@ -55,14 +73,25 @@ test.describe('RSS フィード', () => {
   }) => {
     const { items } = await rssFeedPage.content();
 
-    expect(items.length).toBeGreaterThan(0);
+    expect(
+      items.length,
+      'RSS フィードに記事が 1 件以上含まれる',
+    ).toBeGreaterThan(0);
     // hasRequiredFrontmatter (title + pubDate) を通過した記事だけが並ぶため、
     // 全 item が title・link を持つ。
     for (const item of items) {
-      expect(item.title).not.toBe('');
-      expect(item.link).not.toBe('');
+      expect(
+        item.title,
+        `RSS item (${item.link}) のタイトルが空でない`,
+      ).not.toBe('');
+      expect(item.link, `RSS item「${item.title}」のリンクが空でない`).not.toBe(
+        '',
+      );
     }
     // 記事テンプレート (title 未設定) はフィードに出現しない。
-    expect(items.some((item) => item.link.includes('/template/'))).toBe(false);
+    expect(
+      items.some((item) => item.link.includes('/template/')),
+      '記事テンプレートが RSS フィードから除外される',
+    ).toBe(false);
   });
 });

--- a/tests/e2e/specs/smoke.spec.ts
+++ b/tests/e2e/specs/smoke.spec.ts
@@ -8,24 +8,42 @@ test.describe('スモークテスト', () => {
   }) => {
     await homePage.goto();
 
-    await expect(homePage.page).toHaveTitle(/Blog.*Daiki Sato/);
+    await expect(
+      homePage.page,
+      'ホームページのタイトルに Blog とサイト名が含まれる',
+    ).toHaveTitle(/Blog.*Daiki Sato/);
 
-    await expect(homePage.postList.sampleArticleLink).toBeVisible();
+    await expect(
+      homePage.postList.sampleArticleLink,
+      'ホームページの記事一覧にサンプル記事リンクが表示される',
+    ).toBeVisible();
   });
 
   test('About ページが読み込まれる', async ({ aboutPage }) => {
     await aboutPage.goto();
 
-    await expect(aboutPage.page).toHaveTitle(/About.*Daiki Sato/);
-    await expect(aboutPage.heading).toBeVisible();
+    await expect(
+      aboutPage.page,
+      'About ページのタイトルに About とサイト名が含まれる',
+    ).toHaveTitle(/About.*Daiki Sato/);
+    await expect(
+      aboutPage.heading,
+      'About ページに Daiki Sato の見出しが表示される',
+    ).toBeVisible();
   });
 
   test('サンプル記事が読み込まれる', async ({ articlePage }) => {
     await articlePage.goto();
 
-    await expect(articlePage.page).toHaveTitle(
+    await expect(
+      articlePage.page,
+      `サンプル記事のタイトルに「${sampleArticleTitle}」とサイト名が含まれる`,
+    ).toHaveTitle(
       new RegExp(`${escapeRegExp(sampleArticleTitle)}.*Daiki Sato`),
     );
-    await expect(articlePage.heading).toBeVisible();
+    await expect(
+      articlePage.heading,
+      `サンプル記事に「${sampleArticleTitle}」の見出しが表示される`,
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/specs/tag.spec.ts
+++ b/tests/e2e/specs/tag.spec.ts
@@ -12,31 +12,50 @@ test.describe('タグページ', () => {
   test('代表タグページにアクセスできる', async ({ tagPage, page }) => {
     await tagPage.goto(sampleTag);
 
-    await expect(page).toHaveURL(/\/tags\//);
-    await expect(tagPage.page).toHaveTitle(
-      new RegExp(`${escapeRegExp(sampleTag)}.*Daiki Sato`),
-    );
+    await expect(
+      page,
+      `タグ「${sampleTag}」のページが /tags/ 配下に表示される`,
+    ).toHaveURL(/\/tags\//);
+    await expect(
+      tagPage.page,
+      `タグページのタイトルに「${sampleTag}」とサイト名が含まれる`,
+    ).toHaveTitle(new RegExp(`${escapeRegExp(sampleTag)}.*Daiki Sato`));
   });
 
   test('見出しに対象タグ名が表示される', async ({ tagPage }) => {
     await tagPage.goto(sampleTag);
 
-    await expect(tagPage.heading).toBeVisible();
-    await expect(tagPage.heading).toContainText(sampleTag);
+    await expect(
+      tagPage.heading,
+      `タグ「${sampleTag}」のページに主要見出しが表示される`,
+    ).toBeVisible();
+    await expect(
+      tagPage.heading,
+      `タグページの主要見出しに「${sampleTag}」が含まれる`,
+    ).toContainText(sampleTag);
   });
 
   test('対象タグの記事リンクが表示される', async ({ tagPage }) => {
     await tagPage.goto(sampleTag);
 
-    await expect(tagPage.postList.sampleArticleLink).toBeVisible();
+    await expect(
+      tagPage.postList.sampleArticleLink,
+      `タグ「${sampleTag}」の記事一覧にサンプル記事リンクが表示される`,
+    ).toBeVisible();
   });
 
   test('タグページのリストから記事に遷移できる', async ({ tagPage, page }) => {
     await tagPage.goto(sampleTag);
     await tagPage.postList.sampleArticleLink.click();
 
-    await expect(page).toHaveURL(/\/posts\/audio-interface-under-the-desk\/?$/);
-    await expect(tagPage.page).toHaveTitle(
+    await expect(
+      page,
+      'タグページのサンプル記事リンクから代表記事 URL に遷移する',
+    ).toHaveURL(/\/posts\/audio-interface-under-the-desk\/?$/);
+    await expect(
+      tagPage.page,
+      `タグページから遷移した記事のタイトルに「${sampleArticleTitle}」とサイト名が含まれる`,
+    ).toHaveTitle(
       new RegExp(`${escapeRegExp(sampleArticleTitle)}.*Daiki Sato`),
     );
   });

--- a/tests/e2e/specs/theme.spec.ts
+++ b/tests/e2e/specs/theme.spec.ts
@@ -49,7 +49,7 @@ test.describe('テーマトグル', () => {
     ).not.toHaveAttribute('class', LIGHT);
     await expect
       .poll(() => page.evaluate(() => localStorage.getItem('theme')), {
-        message: '初期状態では localStorage にテーマが保存されていない',
+        message: '初期状態では localStorage の theme に値が保存されていない',
       })
       .toBeNull();
 
@@ -61,7 +61,8 @@ test.describe('テーマトグル', () => {
     ).toHaveAttribute('class', DARK);
     await expect
       .poll(() => page.evaluate(() => localStorage.getItem('theme')), {
-        message: '1 回目のテーマ切り替え後は theme に dark が保存される',
+        message:
+          '1 回目のテーマ切り替え後は localStorage の theme に dark が保存される',
       })
       .toBe('dark');
 
@@ -73,7 +74,7 @@ test.describe('テーマトグル', () => {
     ).toHaveAttribute('class', DARK);
     await expect
       .poll(() => page.evaluate(() => localStorage.getItem('theme')), {
-        message: 'リロード後も theme に dark が保存されている',
+        message: 'リロード後も localStorage の theme に dark が保存されている',
       })
       .toBe('dark');
 
@@ -85,7 +86,8 @@ test.describe('テーマトグル', () => {
     ).toHaveAttribute('class', LIGHT);
     await expect
       .poll(() => page.evaluate(() => localStorage.getItem('theme')), {
-        message: '2 回目のテーマ切り替え後は theme に light が保存される',
+        message:
+          '2 回目のテーマ切り替え後は localStorage の theme に light が保存される',
       })
       .toBe('light');
 
@@ -101,7 +103,8 @@ test.describe('テーマトグル', () => {
     ).not.toHaveAttribute('class', LIGHT);
     await expect
       .poll(() => page.evaluate(() => localStorage.getItem('theme')), {
-        message: '3 回目のテーマ切り替え後は保存済みテーマが削除される',
+        message:
+          '3 回目のテーマ切り替え後は localStorage の theme から保存値が削除される',
       })
       .toBeNull();
   });

--- a/tests/e2e/specs/theme.spec.ts
+++ b/tests/e2e/specs/theme.spec.ts
@@ -39,39 +39,70 @@ test.describe('テーマトグル', () => {
     const html = page.locator('html');
 
     // 新規コンテキスト => テーマ未保存 => <html> には明示的なクラスなし。
-    await expect(html).not.toHaveAttribute('class', DARK);
-    await expect(html).not.toHaveAttribute('class', LIGHT);
+    await expect(
+      html,
+      '初期状態では html 要素に dark クラスが付かない',
+    ).not.toHaveAttribute('class', DARK);
+    await expect(
+      html,
+      '初期状態では html 要素に light クラスが付かない',
+    ).not.toHaveAttribute('class', LIGHT);
     await expect
-      .poll(() => page.evaluate(() => localStorage.getItem('theme')))
+      .poll(() => page.evaluate(() => localStorage.getItem('theme')), {
+        message: '初期状態では localStorage にテーマが保存されていない',
+      })
       .toBeNull();
 
     // 1 回目のクリック: 現在は system（null）、システムは light => dark を適用。
     await toggleTheme();
-    await expect(html).toHaveAttribute('class', DARK);
+    await expect(
+      html,
+      '1 回目のテーマ切り替え後は html 要素に dark クラスが付く',
+    ).toHaveAttribute('class', DARK);
     await expect
-      .poll(() => page.evaluate(() => localStorage.getItem('theme')))
+      .poll(() => page.evaluate(() => localStorage.getItem('theme')), {
+        message: '1 回目のテーマ切り替え後は theme に dark が保存される',
+      })
       .toBe('dark');
 
     // 永続化: リロードすると localStorage からテーマを復元する。
     await page.reload();
-    await expect(html).toHaveAttribute('class', DARK);
+    await expect(
+      html,
+      'リロード後は html 要素に dark クラスが復元される',
+    ).toHaveAttribute('class', DARK);
     await expect
-      .poll(() => page.evaluate(() => localStorage.getItem('theme')))
+      .poll(() => page.evaluate(() => localStorage.getItem('theme')), {
+        message: 'リロード後も theme に dark が保存されている',
+      })
       .toBe('dark');
 
     // 2 回目のクリック: 現在は dark、システムは light => light を適用。
     await toggleTheme();
-    await expect(html).toHaveAttribute('class', LIGHT);
+    await expect(
+      html,
+      '2 回目のテーマ切り替え後は html 要素に light クラスが付く',
+    ).toHaveAttribute('class', LIGHT);
     await expect
-      .poll(() => page.evaluate(() => localStorage.getItem('theme')))
+      .poll(() => page.evaluate(() => localStorage.getItem('theme')), {
+        message: '2 回目のテーマ切り替え後は theme に light が保存される',
+      })
       .toBe('light');
 
     // 3 回目のクリック: 現在は light、システムは light => system に戻す。
     await toggleTheme();
-    await expect(html).not.toHaveAttribute('class', DARK);
-    await expect(html).not.toHaveAttribute('class', LIGHT);
+    await expect(
+      html,
+      '3 回目のテーマ切り替え後は html 要素に dark クラスが付かない',
+    ).not.toHaveAttribute('class', DARK);
+    await expect(
+      html,
+      '3 回目のテーマ切り替え後は html 要素に light クラスが付かない',
+    ).not.toHaveAttribute('class', LIGHT);
     await expect
-      .poll(() => page.evaluate(() => localStorage.getItem('theme')))
+      .poll(() => page.evaluate(() => localStorage.getItem('theme')), {
+        message: '3 回目のテーマ切り替え後は保存済みテーマが削除される',
+      })
       .toBeNull();
   });
 });

--- a/tests/e2e/specs/toc.spec.ts
+++ b/tests/e2e/specs/toc.spec.ts
@@ -15,26 +15,38 @@ test.describe('目次 (TOC)', () => {
   }) => {
     await articlePage.goto();
 
-    await expect(articlePage.toc.root).toBeVisible();
+    await expect(
+      articlePage.toc.root,
+      '見出しを持つ記事に目次ナビゲーションが表示される',
+    ).toBeVisible();
     const headingTexts = await articlePage.sectionHeadings.allTextContents();
-    expect(headingTexts.length).toBeGreaterThan(0);
+    expect(
+      headingTexts.length,
+      '記事本文に目次の対象となる見出しが 1 件以上ある',
+    ).toBeGreaterThan(0);
 
     // TOC 項目はレンダリングされた本文見出しと一致する。
-    await expect(articlePage.toc.links).toHaveCount(headingTexts.length);
-    await expect(articlePage.toc.links).toHaveText(headingTexts);
+    await expect(
+      articlePage.toc.links,
+      `目次に記事本文の見出しと同じ ${headingTexts.length} 件のリンクが表示される`,
+    ).toHaveCount(headingTexts.length);
+    await expect(
+      articlePage.toc.links,
+      '目次リンクのテキストが記事本文の見出しと一致する',
+    ).toHaveText(headingTexts);
   });
 
   test('初期状態では最初の見出しが current になる', async ({ articlePage }) => {
     await articlePage.goto();
 
-    await expect(articlePage.toc.links.first()).toHaveAttribute(
-      'aria-current',
-      'location',
-    );
-    await expect(articlePage.toc.links.last()).not.toHaveAttribute(
-      'aria-current',
-      'location',
-    );
+    await expect(
+      articlePage.toc.links.first(),
+      'ページ初期表示では最初の目次リンクが current になる',
+    ).toHaveAttribute('aria-current', 'location');
+    await expect(
+      articlePage.toc.links.last(),
+      'ページ初期表示では最後の目次リンクが current にならない',
+    ).not.toHaveAttribute('aria-current', 'location');
   });
 
   test('TOC リンクをクリックすると該当見出しへ移動し current が更新される', async ({
@@ -46,23 +58,37 @@ test.describe('目次 (TOC)', () => {
     const linkName = '今回やったこと';
     const link = articlePage.toc.link(linkName);
     const href = await link.getAttribute('href');
-    expect(href).toMatch(/^#.+/);
+    expect(
+      href,
+      `目次リンク「${linkName}」の href がページ内ハッシュである`,
+    ).toMatch(/^#.+/);
 
     await link.click();
 
     // ハッシュが URL に反映される（非 ASCII はパーセントエンコードされるので復号して比較）。
     await expect
-      .poll(async () => decodeURIComponent(new URL(page.url()).hash))
+      .poll(async () => decodeURIComponent(new URL(page.url()).hash), {
+        message: `目次リンク「${linkName}」のクリック後は URL ハッシュがリンク先と一致する`,
+      })
       .toBe(href);
 
     // 対象見出しがビューポート内にスクロールされる。
     const id = await link.getAttribute('data-toc-id');
     const heading = page.locator(`[id="${id}"]`);
-    await expect(heading).toBeInViewport();
+    await expect(
+      heading,
+      `目次リンク「${linkName}」のクリック後は対応する見出しがビューポート内に表示される`,
+    ).toBeInViewport();
 
     // クリック（ハッシュ変更）後に対応リンクが current になる。
-    await expect(articlePage.toc.currentLink).toHaveCount(1);
-    await expect(link).toHaveAttribute('aria-current', 'location');
+    await expect(
+      articlePage.toc.currentLink,
+      `目次リンク「${linkName}」のクリック後は current リンクが 1 件になる`,
+    ).toHaveCount(1);
+    await expect(
+      link,
+      `目次リンク「${linkName}」のクリック後はそのリンクが current になる`,
+    ).toHaveAttribute('aria-current', 'location');
   });
 
   test('スクロール位置に応じて current が更新される', async ({
@@ -76,11 +102,14 @@ test.describe('目次 (TOC)', () => {
       window.scrollTo(0, document.documentElement.scrollHeight),
     );
 
-    await expect(articlePage.toc.links.last()).toHaveAttribute(
-      'aria-current',
-      'location',
-    );
-    await expect(articlePage.toc.currentLink).toHaveCount(1);
+    await expect(
+      articlePage.toc.links.last(),
+      'ページ末尾へのスクロール後は最後の目次リンクが current になる',
+    ).toHaveAttribute('aria-current', 'location');
+    await expect(
+      articlePage.toc.currentLink,
+      'ページ末尾へのスクロール後も current リンクが 1 件だけになる',
+    ).toHaveCount(1);
   });
 
   test('デスクトップとモバイルで表示される TOC は1つだけ', async ({
@@ -94,7 +123,13 @@ test.describe('目次 (TOC)', () => {
     // `getByRole('navigation')` は `display:none` の nav をアクセシビリティツリーから
     // 除くため見落とすので、`data-toc-root` 属性で DOM 上の全件を数える。
     const allRoots = page.locator('[data-toc-root]');
-    await expect(allRoots).toHaveCount(2);
-    await expect(allRoots.filter({ visible: true })).toHaveCount(1);
+    await expect(
+      allRoots,
+      'デスクトップ用とモバイル用の目次が DOM に 2 件存在する',
+    ).toHaveCount(2);
+    await expect(
+      allRoots.filter({ visible: true }),
+      '現在のビューポートに対応する目次だけが 1 件表示される',
+    ).toHaveCount(1);
   });
 });

--- a/tests/e2e/specs/visual.spec.ts
+++ b/tests/e2e/specs/visual.spec.ts
@@ -39,27 +39,27 @@ test.describe('ビジュアルリグレッション', () => {
   test('記事メタデータブロック', async ({ articlePage }) => {
     await articlePage.goto();
 
-    await expect(articlePage.metadata.root).toHaveScreenshot(
-      'article-metadata.png',
-      screenshotOptions,
-    );
+    await expect(
+      articlePage.metadata.root,
+      '記事メタデータブロックがビジュアルスナップショットと一致する',
+    ).toHaveScreenshot('article-metadata.png', screenshotOptions);
   });
 
   test('サイトヘッダー', async ({ homePage }) => {
     await homePage.goto();
 
-    await expect(homePage.header.root).toHaveScreenshot(
-      'header.png',
-      screenshotOptions,
-    );
+    await expect(
+      homePage.header.root,
+      'サイトヘッダーがビジュアルスナップショットと一致する',
+    ).toHaveScreenshot('header.png', screenshotOptions);
   });
 
   test('ホームのサンプル記事リスト項目', async ({ homePage }) => {
     await homePage.goto();
 
-    await expect(homePage.postList.sampleArticleLink).toHaveScreenshot(
-      'home-sample-article-item.png',
-      screenshotOptions,
-    );
+    await expect(
+      homePage.postList.sampleArticleLink,
+      'ホームのサンプル記事リスト項目がビジュアルスナップショットと一致する',
+    ).toHaveScreenshot('home-sample-article-item.png', screenshotOptions);
   });
 });


### PR DESCRIPTION
## 概要

- `tests/e2e/` 配下の全 Playwright `expect` に、期待内容を示す日本語 custom message を追加
- `expect.poll` は Playwright 公式 API に従い `options.message` を使用
- E2E テストのメッセージ運用ルール、設計書、実装計画をドキュメント化

## 背景

従来の Playwright レポートでは assertion の matcher は確認できても、同じテスト内で「どの状態・操作結果を期待しているか」をすぐ判別しにくい箇所がありました。custom message を各 assertion に直接付け、成功・失敗どちらのレポートでもテスト意図を読み取れるようにします。

## 変更内容

- 通常の assertion を `expect(actual, message)` 形式に統一
- `expect.poll(callback, { message })` でポーリングの意図を明示
- 初期状態、操作後、リロード後など類似 assertion の文脈を区別
- RSS のループ assertion では対象 item を message に含め、失敗箇所を特定可能に変更
- `docs/e2e-testing.md` に運用ルールと Playwright 公式ドキュメントへのリンクを追加

## 影響

テスト対象、matcher、期待値は変更していません。Playwright レポートの assertion step 表示だけが分かりやすくなります。

## 検証

- [x] TypeScript AST 網羅性チェック: direct `expect` 68件 + `expect.poll` 6件、message 欠落 0件
- [x] `pnpm run lint`
- [x] `pnpm run test:e2e` — 152 passed / 28 skipped / 0 failed
- [x] `git diff --check`
- [x] 仕様準拠レビュー、コード品質レビュー、全体最終レビュー

## 参考

- [Playwright: Custom expect message](https://playwright.dev/docs/test-assertions#custom-expect-message)
- [Playwright: expect.poll](https://playwright.dev/docs/test-assertions#expectpoll)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated E2E testing guidance with clearer rules for writing assertions and reportable messages.
  * Added design and implementation plan documents for the E2E expectation-message convention.

* **Tests**
  * Improved Playwright E2E checks across navigation, 404, RSS, TOC, theme, visual, and smoke scenarios.
  * Added more descriptive assertion messages to make failures easier to understand and diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->