### PR TITLE
fix(markdown): raw MarkdownのUTF-8 charsetを保証する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Run lint
         run: pnpm run lint
 
+      - name: Run Worker tests
+        run: pnpm run test:worker
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -11,6 +11,7 @@ Astro のビルド結果を `astro preview` で起動し、スモークテスト
 ## コマンド
 
 - `pnpm run test:e2e`: ヘッドレスで全 E2E テストを実行
+- `pnpm run test:worker`: Worker の公開 HTTP レスポンス境界を Node.js Test Runner で検証
 - `pnpm run test:e2e:headed`: ブラウザを表示して実行
 - `pnpm run test:e2e:ui`: Playwright UI モードで実行
 - `pnpm run test:e2e:update`: ビジュアルスナップショットを更新
@@ -269,11 +270,11 @@ pnpm exec playwright test tests/e2e/specs/visual.spec.ts --update-snapshots
 
 - 代表記事の `.md` URL が `200` を返す
 - `Content-Type` が `text/markdown` で始まる
-  - 本番（Cloudflare Workers Static Assets）では `text/markdown; charset=utf-8` になりますが、`astro preview` は `text/markdown` のみを返すため、spec では `text/markdown` であることだけを検証します。`charset=utf-8` の厳密検証は Workers プレビューが必要なため別途切り出します。
+  - `astro preview` は `text/markdown` のみを返すため、Playwright spec では media type だけを検証します。Worker による `charset=utf-8` の補完は `pnpm run test:worker` で厳密に検証します。
 - frontmatter（`title` / `description`）と本文が含まれる
 - Astro 表示用の `layout` frontmatter は除去されている（`^layout:` 行が存在しない）
 
-通常記事 URL + `Accept: text/markdown` による content negotiation は `src/worker.ts` で実装されており Workers プレビュー側でのみ機能します。`astro preview` では Worker を経由しないため本 spec ではカバーせず、別 Issue で取り扱います。
+通常記事 URL + `Accept: text/markdown` による content negotiation と、Cloudflare Workers Static Assets の応答に `charset=utf-8` を補う処理は `src/worker.ts` で実装しています。これらは `tests/worker/markdown-response.test.ts` で Worker の `fetch` 境界から検証し、直接の `.md` URLと content negotiation の両方が `Content-Type: text/markdown; charset=utf-8` を返すことを保証します。
 
 ## GitHub Actions
 

--- a/docs/raw-markdown-endpoints.md
+++ b/docs/raw-markdown-endpoints.md
@@ -22,7 +22,7 @@ Raw Markdown の生成は `src/pages/posts/[slug].md.ts` で実装していま�
 - `import.meta.glob('./*.md', { query: '?raw', import: 'default', eager: true })` で `src/pages/posts/` 直下の記事 Markdown を文字列として読み込む
 - `getStaticPaths()` で記事ごとの `slug` を列挙し、静的ビルド時に `/posts/[slug].md` を生成する
 - 読み込んだ Markdown の frontmatter から `layout` 行を除去する
-- `GET` は raw Markdown を `Content-Type: text/markdown; charset=utf-8` で返す
+- `GET` は raw Markdown を返し、Worker が最終レスポンスの `Content-Type` を `text/markdown; charset=utf-8` に正規化する
 
 `template/_blog-post.md` や画像ディレクトリ配下のファイルは、`./*.md` の対象外です。
 
@@ -33,7 +33,7 @@ Raw Markdown の生成は `src/pages/posts/[slug].md.ts` で実装していま�
 - `Accept` ヘッダーの `q` 値、ワイルドカード、同じ `q` 値での記述順を考慮する
 - キャッシュが `Accept` ごとに分かれるよう、Markdown 返却時に `Vary: Accept` を付与する
 
-Worker 側は `.md` への振り分けだけを担当し、raw Markdown の生成処理は Astro の endpoint に寄せています。別ホスティングへ移植する場合は、この振り分け層だけを移植先の middleware / edge function / rewrite に置き換えます。
+Worker 側は `.md` への振り分けに加え、Cloudflare Workers Static Assets が拡張子から付与する `text/markdown` に `charset=utf-8` を補います。raw Markdown の生成処理自体は Astro の endpoint に寄せています。別ホスティングへ移植する場合は、この振り分け・ヘッダー正規化層を移植先の middleware / edge function / rewrite に置き換えます。
 
 ## 動作確認
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "hooks:install": "bash scripts/git-hooks/install.sh",
     "hooks:uninstall": "bash scripts/git-hooks/uninstall.sh",
     "test:git-hooks": "bash tests/git-hooks/hooks.test.sh",
+    "test:worker": "node --test tests/worker/*.test.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,6 +5,7 @@ interface Env {
 }
 
 const POSTS_PATH_PATTERN = /^\/posts\/[^/.]+\/?$/;
+const MARKDOWN_POSTS_PATH_PATTERN = /^\/posts\/[^/]+\.md$/;
 
 interface AcceptPreference {
   mediaType: string;
@@ -106,6 +107,20 @@ const addVaryAccept = (response: Response) => {
   });
 };
 
+const addMarkdownCharset = (response: Response) => {
+  const headers = new Headers(response.headers);
+
+  if (headers.get('Content-Type')?.split(';', 1)[0] === 'text/markdown') {
+    headers.set('Content-Type', 'text/markdown; charset=utf-8');
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
 export default {
   async fetch(request: Request, env: Env) {
     const url = new URL(request.url);
@@ -122,9 +137,13 @@ export default {
         new Request(markdownUrl, request),
       );
 
-      return addVaryAccept(response);
+      return addVaryAccept(addMarkdownCharset(response));
     }
 
-    return env.ASSETS.fetch(request);
+    const response = await env.ASSETS.fetch(request);
+
+    return MARKDOWN_POSTS_PATH_PATTERN.test(url.pathname)
+      ? addMarkdownCharset(response)
+      : response;
   },
 };

--- a/tests/e2e/specs/raw-markdown.spec.ts
+++ b/tests/e2e/specs/raw-markdown.spec.ts
@@ -11,15 +11,13 @@ import {
  * Astro の静的ビルドで `/posts/[slug].md` が生成され、`astro preview` から配信される。
  * 実装は `src/pages/posts/[slug].md.ts`、仕様は `docs/raw-markdown-endpoints.md` 参照。
  *
- * `Content-Type` は本番（Cloudflare Workers Static Assets）では
- * `text/markdown; charset=utf-8` になるが、E2E で使う `astro preview` は
- * `text/markdown` のみを返す。そのため charset 部分は厳密に検証せず、
- * `text/markdown` であることだけを確認する（charset の厳密検証は Workers
- * プレビューが必要なため別途切り出す）。
+ * `astro preview` は `Content-Type: text/markdown` のみを返すため、ここでは
+ * media type だけを確認する。Worker が付与する `charset=utf-8` は
+ * `tests/worker/markdown-response.test.ts` で検証する。
  *
  * 通常記事 URL + `Accept: text/markdown` による content negotiation は
  * `src/worker.ts` で実装されており、Workers プレビュー側でのみ機能する。
- * `astro preview` では Worker を経由しないため本 spec の対象外とし、別 Issue で扱う。
+ * `astro preview` では Worker を経由しないため、本 spec ではなく Worker テストで扱う。
  */
 test.describe('raw Markdown エンドポイント', () => {
   test('代表記事の .md URL が raw Markdown を返す', async ({ request }) => {

--- a/tests/worker/markdown-response.test.ts
+++ b/tests/worker/markdown-response.test.ts
@@ -4,19 +4,22 @@ import worker from '../../src/worker.ts';
 
 const markdownBody = '# 日本語の記事\n';
 
-const createEnv = () => ({
+const createEnv = (expectedPathname: string) => ({
   ASSETS: {
-    fetch: async () =>
-      new Response(markdownBody, {
+    fetch: async (request: Request) => {
+      assert.equal(new URL(request.url).pathname, expectedPathname);
+
+      return new Response(markdownBody, {
         headers: { 'Content-Type': 'text/markdown' },
-      }),
+      });
+    },
   },
 });
 
 test('direct .md response declares UTF-8 in Content-Type', async () => {
   const response = await worker.fetch(
     new Request('https://example.com/posts/example.md'),
-    createEnv(),
+    createEnv('/posts/example.md'),
   );
 
   assert.equal(response.status, 200);
@@ -32,7 +35,7 @@ test('negotiated Markdown response declares UTF-8 in Content-Type', async () => 
     new Request('https://example.com/posts/example', {
       headers: { Accept: 'text/markdown' },
     }),
-    createEnv(),
+    createEnv('/posts/example.md'),
   );
 
   assert.equal(response.status, 200);

--- a/tests/worker/markdown-response.test.ts
+++ b/tests/worker/markdown-response.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import worker from '../../src/worker.ts';
+
+const markdownBody = '# 日本語の記事\n';
+
+const createEnv = () => ({
+  ASSETS: {
+    fetch: async () =>
+      new Response(markdownBody, {
+        headers: { 'Content-Type': 'text/markdown' },
+      }),
+  },
+});
+
+test('direct .md response declares UTF-8 in Content-Type', async () => {
+  const response = await worker.fetch(
+    new Request('https://example.com/posts/example.md'),
+    createEnv(),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(
+    response.headers.get('Content-Type'),
+    'text/markdown; charset=utf-8',
+  );
+  assert.equal(await response.text(), markdownBody);
+});
+
+test('negotiated Markdown response declares UTF-8 in Content-Type', async () => {
+  const response = await worker.fetch(
+    new Request('https://example.com/posts/example', {
+      headers: { Accept: 'text/markdown' },
+    }),
+    createEnv(),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(
+    response.headers.get('Content-Type'),
+    'text/markdown; charset=utf-8',
+  );
+  assert.equal(response.headers.get('Vary'), 'Accept');
+  assert.equal(await response.text(), markdownBody);
+});


### PR DESCRIPTION
### 概要

Safariでraw Markdownを開いた際に日本語が文字化けする問題を修正します。

Cloudflare Workers Static Assetsの応答が`Content-Type: text/markdown`となる場合でも、Workerで`charset=utf-8`を補完します。

### 変更内容

- `/posts/*.md`の直接アクセスで`Content-Type: text/markdown; charset=utf-8`を返す
- `Accept: text/markdown`によるcontent negotiationでも同じcharsetを返す
- Workerの公開`fetch`境界をNode.js Test Runnerで検証する回帰テストを追加
- WorkerテストをCIのLintジョブへ追加
- raw Markdownとテスト構成のドキュメントを更新

### TDD確認

修正前に新しいWorkerテストを実行し、次の差分で失敗することを確認しました。

```text
actual:   text/markdown
expected: text/markdown; charset=utf-8
```

実装後は直接`.md`とcontent negotiationの2ケースがともに成功します。

### 検証

- `pnpm run test:worker` — 2 passed
- `pnpm run lint` — passed
- `pnpm run format:check` — passed
- `pnpm run test:e2e` — 158 passed / 34 skipped
- `bash tests/git-hooks/hooks.test.sh` — passed
- pre-commit build — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Raw Markdown responses now consistently include the UTF-8 charset in their `Content-Type` header.
  - Both direct `.md` requests and content-negotiated Markdown responses preserve the expected `Vary: Accept` behavior.
  - Other response types remain unchanged.

- **Documentation**
  - Clarified raw Markdown endpoint behavior and testing coverage.

- **Tests**
  - Added coverage for Markdown response headers, status codes, and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->